### PR TITLE
Create dir when overriding .desktop.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ sudo apt -y -t unstable install chromium chromium-sandbox chromium-l10n chromium
 # Add --no-sandbox option to .desktop file for Termux, sandbox does not work
 # with proot.
 if [ -n "$ANDROID_ROOT" ]; then
+	mkdir -p ~/.local/share/applications
 	sed -e 's,^Exec=/usr/bin/chromium ,& --no-sandbox ,' /usr/share/applications/chromium.desktop \
 		> ~/.local/share/applications/chromium.desktop
 


### PR DESCRIPTION
Make sure ~/.local/share/applications exists before putting the .desktop
override there for Android.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>